### PR TITLE
Explict scope for `maven-plugin-api`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,7 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>3.9.16</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>


### PR DESCRIPTION
Fixes:

```
[INFO] --- plugin:3.15.2:descriptor (default-descriptor) @ glassfish-doc-maven-plugin ---
[WARNING]

Some dependencies of Maven Plugins are expected to be in provided scope.
Please make sure that dependencies listed below declared in POM
have set '<scope>provided</scope>' as well.

The following dependencies are in wrong scope:
 * org.apache.maven:maven-plugin-api:jar:3.9.16:compile
 * org.apache.maven:maven-model:jar:3.9.16:compile
 * org.apache.maven:maven-artifact:jar:3.9.16:compile
```